### PR TITLE
README: Make cronjob example silent

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Once you have stored credentials, you can also automate the index update by addi
 
 ```sh
 # GitHub stars
-0 6 * * *	~/.local/bin/mystars -u
+0 6 * * *	~/.local/bin/mystars -u >~/.oh-my-stars/update.log
 ```
 
 ### Installation (Mac OSX)


### PR DESCRIPTION
Avoid a daily mail in mail-enabled crontabs, by redirecting stdout to a log file.